### PR TITLE
refactor: rename hop2.sh to init.sh for cleaner setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ hop2 kdp my-pod-name
 curl -sL [https://raw.githubusercontent.com/vishukamble/hop2/main/install.sh](https://raw.githubusercontent.com/vishukamble/hop2/main/install.sh) | bash
 
 # 2. Enable shell integration
-echo 'source ~/.hop2/hop2.sh' >> ~/.bashrc   # or ~/.zshrc
+echo 'source ~/.hop2/init.sh' >> ~/.bashrc   # or ~/.zshrc
 source ~/.bashrc
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -531,7 +531,7 @@
                     <div>
                         <p>Add to your shell configuration:</p>
                         <div class="terminal">
-                            <pre><span class="prompt">$</span> <span class="command">echo 'source ~/.hop2/hop2.sh' >> ~/.bashrc</span>
+                            <pre><span class="prompt">$</span> <span class="command">echo 'source ~/.hop2/init.sh' >> ~/.bashrc</span>
 <span class="prompt">$</span> <span class="command">source ~/.bashrc</span></pre>
                         </div>
                     </div>

--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # hop2 shell integration
 # Add this to your ~/.bashrc or ~/.zshrc:
-#   source ~/.hop2/hop2.sh
+#   source ~/.hop2/init.sh
 
 # Main hop2 function that handles directory changes and command shortcuts
 hop2() {

--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # hop2 shell integration
 # Add this to your ~/.bashrc or ~/.zshrc:
-#   source ~/.hop2/init.sh
+# source ~/.hop2/init.sh
 
 # Main hop2 function that handles directory changes and command shortcuts
 hop2() {
@@ -47,7 +47,6 @@ h() {
         hop2 go "$1"
     fi
 }
-
 # Bash completion
 _hop2_completion() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -76,12 +75,18 @@ if [ -n "$BASH_VERSION" ]; then
     complete -F _hop2_completion h
 fi
 
+if [ -n "$BASH_VERSION" ]; then
+    complete -F _hop2_completion hop2
+    complete -F _hop2_completion h2
+    complete -F _hop2_completion h
+fi
+
 # Zsh completion
 if [ -n "$ZSH_VERSION" ]; then
     _hop2() {
         local -a all_aliases
-        all_aliases=(${(f)"$(sqlite3 ~/.hop2/hop2.db \
-            "SELECT alias FROM directories UNION SELECT alias FROM commands" 2>/dev/null)"})
+        # shellcheck disable=SC2296
+        all_aliases=(${(f)"$(sqlite3 ~/.hop2/hop2.db 'SELECT alias FROM directories UNION SELECT alias FROM commands' 2>/dev/null)"})
         _arguments "1:command:(add cmd list rm go $all_aliases)"
     }
     compdef _hop2 hop2 h2 h

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# hop2 installer script
+# hop2 shell integration
+# Add this to your ~/.bashrc or ~/.zshrc:
+#   source ~/.hop2/init.sh
 
 set -e
 
@@ -26,13 +28,13 @@ fi
 mkdir -p "$HOME/.hop2"
 
 echo "Downloading hop2 core..."
-# Download hop2.py
+# Download hop2.py and init.sh (renamed from init.sh)
 if command -v curl &> /dev/null; then
     curl -sL https://raw.githubusercontent.com/vishukamble/hop2/main/hop2.py -o /tmp/hop2
-    curl -sL https://raw.githubusercontent.com/vishukamble/hop2/main/hop2.sh -o "$HOME/.hop2/hop2.sh"
+    curl -sL https://raw.githubusercontent.com/vishukamble/hop2/main/init.sh -o "$HOME/.hop2/init.sh"
 elif command -v wget &> /dev/null; then
     wget -q https://raw.githubusercontent.com/vishukamble/hop2/main/hop2.py -O /tmp/hop2
-    wget -q https://raw.githubusercontent.com/vishukamble/hop2/main/hop2.sh -O "$HOME/.hop2/hop2.sh"
+    wget -q https://raw.githubusercontent.com/vishukamble/hop2/main/init.sh -O "$HOME/.hop2/init.sh"
 else
     echo "Error: curl or wget is required for installation."
     exit 1
@@ -43,7 +45,7 @@ chmod +x /tmp/hop2
 mv /tmp/hop2 "$INSTALL_DIR/hop2"
 
 # Make the shell integration script executable
-chmod +x "$HOME/.hop2/hop2.sh"
+chmod +x "$HOME/.hop2/init.sh"
 
 echo "✓ hop2 installed successfully to $INSTALL_DIR/hop2"
 echo
@@ -61,9 +63,9 @@ else
 fi
 
 cat <<EOF
-⚠️  To enable directory jumping, add this line to $SHELL_RC:
+To enable directory jumping, add this line to $SHELL_RC:
 
-    source ~/.hop2/hop2.sh
+    source ~/.hop2/init.sh
 
 Then reload your shell:
 


### PR DESCRIPTION
- Rename shell integration script from hop2.sh to init.sh
- Update installer to download init.sh
- Update documentation and landing page
- Cleaner installation message without repetitive hop2/hop